### PR TITLE
Remove Expo dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/caches
+.idea/
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "expo": ">= 27.x",
     "react": ">= 16.x",
-    "react-native": ">= 0.55.x"
+    "react-native": ">= 0.55.x",
+    "expo-haptics": "^6.0.0",
+    "expo-linear-gradient": "^6.0.0"
   },
   "devDependencies": {
     "@types/expo": "^27.0.12",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Platform, StyleSheet, Text, TouchableOpacity } from "react-native";
-import { Haptic, LinearGradient } from "expo";
+import { LinearGradient } from "expo-linear-gradient";
+import * as Haptics from "expo-haptics";
 
 const styles = StyleSheet.create({
   button: {
@@ -74,7 +75,7 @@ class GradientButton extends React.PureComponent {
         style={[styles.button, { height, width }, style]}
         onPress={disabled ? null : () => {
           if (Platform.OS === "ios" && impact === true) {
-            Haptic.impact(Haptic.ImpactFeedbackStyle[impactStyle]);
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle[impactStyle]);
           }
           if (onPressAction) {
             return onPressAction();

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,16 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+expo-haptics@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-6.0.0.tgz#dd0b8390564b3ba398a3f6d726ce5ad99a892ddc"
+  integrity sha512-Xn+u5Gqp0/aLipKUMhPgZrccTO9uSV5FSM9u6bkMhV/zfjZqQMWpm0NqL24OBBXy5wPmF3g6Hev5YyDUd0Jj9Q==
+
+expo-linear-gradient@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-6.0.0.tgz#5fb0fb955dd22ef4ab032e543cb1c249885bf0b5"
+  integrity sha512-TGHSK7MsoU1wZXx9uEivMggAR/KT4wTSE0xBfhB8qsziGXoHZdoT79/tZ3HyWtCG7+JVUEFXfUOBxtOlZOu5tg==
+
 global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"


### PR DESCRIPTION
I've added expo-linear-gradient and expo-haptics to the peer dependencies and changed the source to accommodate the change in the Haptics API. I tested by adding my own repo to my package.json and rm -rf'ing node_modules then yarn install'ing.